### PR TITLE
0.7.1 : node autolabel, consolidate LayerSetKnob validation code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(ExternalProject)
 set(PROJECT_NAME LayerAlchemy)
 set(LAYER_ALCHEMY_VERSION_MAJOR 0)
 set(LAYER_ALCHEMY_VERSION_MINOR 7)
-set(LAYER_ALCHEMY_VERSION_PATCH 0)
+set(LAYER_ALCHEMY_VERSION_PATCH 1)
 
 option(BUILD_APPS "Build binary applications" ON)
 option(BUILD_DOCS "Build html documentation" ON)

--- a/include/nuke/LayerSetKnob.h
+++ b/include/nuke/LayerSetKnob.h
@@ -28,20 +28,36 @@ public:
     LayerSetKnobData();
     ~LayerSetKnobData();
 };
+
+/**
+ * convenience functions directly related to creating and manipulating the enumeration knob
+ */
+
 // centralized function for creating LayerSet Enumeration Knob in a node's knobs() function
 DD::Image::Knob* LayerSetKnob(DD::Image::Knob_Callback&, LayerSetKnobData&);
 // get the current LayerSet on an Op
 string getLayerSetKnobEnumString(DD::Image::Op*);
 void populateLayerSetKnobEnum(DD::Image::Op*, std::vector<string>&);
-// sets text on the Op's label knob
-void setLayerSetNodeLabel(DD::Image::Op*);
 
-// quick check to see if an update is required
-bool _preValidateLayerSetKnobUpdate(DD::Image::Op*, const LayerSetKnobData&, const DD::Image::ChannelSet&);
+/**
+ * validation functions that manage if going through an reconfiguration of the enumeration knob is necessary
+ * Reasons :
+ * - Nuke runs _validate a lot, this eliminates wasting cpu cycles, when possible
+ * - Reliability, we want to give the user a chance to fix any errors, so this handles the assertions
+ */
+
+// first stage of update handling : inexpensive check to see if an update is required
+bool _basicValidateLayerSetKnobUpdate(DD::Image::Op*, const LayerSetKnobData&, const DD::Image::ChannelSet&);
+// second stage of update handling : categorizes the incoming channels, and decides if an update is redundant.
+bool _categorizedValidateLayerSetKnobUpdate(DD::Image::Op*, const LayerMap&, const string&);
 // main validation function for managing LayerSetKnob updating
 bool validateLayerSetKnobUpdate(DD::Image::Op*, const LayerSetKnobData&, LayerCollection&, const DD::Image::ChannelSet&);
 // main validation filtered function for managing LayerSetKnob updating
 bool validateLayerSetKnobUpdate(DD::Image::Op*, const LayerSetKnobData&, LayerCollection&, const DD::Image::ChannelSet&, const CategorizeFilter&);
+
+/**
+ * convenience functions for doing the actual updating of the updating of both the knob and it's storage
+ */
 
 // private function to do the actual data updating to the enumeration knob
 void _updateLayerSetKnob(DD::Image::Op*, LayerSetKnobData&, ChannelSetMapType&, const DD::Image::ChannelSet&);

--- a/python/layer_alchemy/_config.py
+++ b/python/layer_alchemy/_config.py
@@ -60,7 +60,7 @@ def _save(collapsedConfigs, yamlFile):
 def _add(configDictList, sort=False):
     """
     Accumulates a list of dictionaries into one output dictionary
-    :param list configDictList: all the config dictionaleirs to process
+    :param list configDictList: all the config dictionaries to process
     :param bool sort: as an option, soft the values
     :return: a dict that contains all keys and values
     :rtype dict

--- a/python/nuke/init.py
+++ b/python/nuke/init.py
@@ -1,18 +1,8 @@
 """LayerAlchemy Nuke init"""
-import nuke
 
-import layer_alchemy.constants
-import layer_alchemy.callbacks
 import layer_alchemy.utilities
+import layer_alchemy.callbacks
 
 if layer_alchemy.utilities.nukeVersionCompatible():
-    layer_alchemy.utilities.validateConfigFileEnvironmentVariables()
-    nuke.pluginAddPath(layer_alchemy.constants.LAYER_ALCHEMY_ICON_DIR)
-    nuke.pluginAddPath(layer_alchemy.utilities.getPluginDirForCurrentNukeVersion())
-
-    # callbacks
-    for pluginName in layer_alchemy.constants.LAYER_ALCHEMY_PLUGINS.keys():
-        nuke.addKnobChanged(
-            lambda: layer_alchemy.callbacks.knobChangedCommon(nuke.thisNode(), nuke.thisKnob()),
-            nodeClass=pluginName
-        )
+    layer_alchemy.utilities.pluginAddPaths()
+    layer_alchemy.callbacks.setupCallbacks()

--- a/python/nuke/layer_alchemy/callbacks.py
+++ b/python/nuke/layer_alchemy/callbacks.py
@@ -53,8 +53,30 @@ def autolabel():
     layerSetKnob = node.knob('layer_set')
     index = int(layerSetKnob.getValue())
     layerSetName = layerSetKnob.enumName(index)
+    node.knob('indicators').setValue(_getIndicatorValue(node))
     if layerSetName:
         return '{name}\n({layerSet})'.format(name=nodeName, layerSet=layerSetName)
     else:
         return nodeName
 
+
+def _getIndicatorValue(node):
+    """
+    simple function to calculate the indicator value for a node
+    :param node: the Nuke node object
+    :type node: :class:`nuke.Node`
+    :return: the integer indicator value
+    :rtype: int
+    """
+    indicators = 0
+    knobs = node.allKnobs()
+    mixKnob = node.knob('mix')
+    if mixKnob and mixKnob.value() != 1:
+        indicators += 16
+    if node.clones():
+        indicators += 8
+    if any(knob.isAnimated() for knob in knobs):
+        indicators += 1
+    if any(knob.hasExpression() for knob in knobs):
+        indicators += 2
+    return indicators

--- a/python/nuke/layer_alchemy/callbacks.py
+++ b/python/nuke/layer_alchemy/callbacks.py
@@ -9,6 +9,19 @@ import utilities
 import constants
 
 
+def setupCallbacks():
+    """
+    Utility function to add all callbacks for plugins in this suite.
+    Adds knobChanged and autolabel callbacks
+    """
+    for pluginName in constants.LAYER_ALCHEMY_PLUGINS.keys():
+        nuke.addKnobChanged(
+            lambda: knobChangedCommon(nuke.thisNode(), nuke.thisKnob()),
+            nodeClass=pluginName
+        )
+        nuke.addAutolabel(autolabel, nodeClass=pluginName)
+
+
 def knobChangedCommon(node, knob):
     """
     Common knobChanged function for plugins in this suite
@@ -28,3 +41,20 @@ def knobChangedCommon(node, knob):
         htmlFile = os.path.join(os.path.dirname(documentationIndex), pluginDocFileName)
         outputPath = htmlFile if os.path.isfile(htmlFile) else documentationIndex
         nukescripts.start(outputPath)
+
+
+def autolabel():
+    """
+    Common autolabel function for plugins in this suite
+    """
+
+    node = nuke.thisNode()
+    nodeName = node.name()
+    layerSetKnob = node.knob('layer_set')
+    index = int(layerSetKnob.getValue())
+    layerSetName = layerSetKnob.enumName(index)
+    if layerSetName:
+        return '{name}\n({layerSet})'.format(name=nodeName, layerSet=layerSetName)
+    else:
+        return nodeName
+

--- a/python/nuke/layer_alchemy/utilities.py
+++ b/python/nuke/layer_alchemy/utilities.py
@@ -8,6 +8,16 @@ import nuke
 import constants
 
 
+def pluginAddPaths():
+    """
+    This validates that configuration files are present and valid
+    and adds the icon and plugin directories to Nuke's pluginPath
+    """
+    validateConfigFileEnvironmentVariables()
+    nuke.pluginAddPath(constants.LAYER_ALCHEMY_ICON_DIR)
+    nuke.pluginAddPath(_getPluginDirForCurrentNukeVersion())
+
+
 def getDocumentationIndexPath():
     """
     Find the absolute path to the documentation's main index.html file
@@ -28,7 +38,7 @@ def getNukeVersionString():
     return '{major}.{minor}'.format(major=nuke.env['NukeVersionMajor'], minor=nuke.env['NukeVersionMinor'])
 
 
-def getPluginDirForCurrentNukeVersion():
+def _getPluginDirForCurrentNukeVersion():
     """
     Utility Function to get the directory path relevant to the current nuke version
     :return: absolute directory path to plugin directory

--- a/src/nuke/FlattenLayerSet.cpp
+++ b/src/nuke/FlattenLayerSet.cpp
@@ -80,7 +80,6 @@ void FlattenLayerSet::_validate(bool for_real) {
         updateLayerSetKnob(this, m_lsKnobData, layerCollection, inChannels);
     }
     set_out_channels(activeChannelSet());
-    setLayerSetNodeLabel(this);
 }
 
 void FlattenLayerSet::pixel_engine(const Row& in, int y, int x, int r, ChannelMask channels, Row& out) {

--- a/src/nuke/GradeBeauty.cpp
+++ b/src/nuke/GradeBeauty.cpp
@@ -34,6 +34,9 @@ static const char* DEFAULT_VALUE_PYSCRIPT =
     "        knob.setDefaultValue(defaultValue)\n"
     "        knob.fromScript(knobToScript)"
 ;
+static const char* autoLabelScript =
+"nuke.thisNode().name() + \"\\n\"+"
+"'(' + nuke.thisNode().knob('layer_set').enumName(int(nuke.thisNode().knob('layer_set').getValue())) + ')' ";
 
 namespace BeautyLayerSetConstants {
     // frequently used lists of layer set category names 
@@ -245,7 +248,6 @@ void GradeBeauty::_validate(bool for_real) {
     
     calculateLayerValues(m_lsKnobData.m_selectedChannels, m_valueMap);
     set_out_channels(activeChannelSet());
-    setLayerSetNodeLabel(this);
     //printf("knob is %s\n", knob("layer_set")->enumerationKnob()->getSelectedItemString().c_str());
 }
 
@@ -359,6 +361,11 @@ void GradeBeauty::knobs(Knob_Callback f) {
     SetFlags(f, Knob::HIDE_ANIMATION_AND_VIEWS | Knob::NO_UNDO | Knob::NO_RERENDER | Knob::STARTLINE);
     Link_knob(f, "reset values", "", "reset values");
     EndToolbar(f);
+    // if (!f.makeKnobs()) {
+    //     Knob* autoLabelKnob = this->knob("autolabel");
+    //     autoLabelKnob->set_flag(Knob::DO_NOT_WRITE);
+    //     autoLabelKnob->set_text(autoLabelScript);
+    // }
 }
 
 int GradeBeauty::knob_changed(Knob* k) {

--- a/src/nuke/GradeBeautyLayerSet.cpp
+++ b/src/nuke/GradeBeautyLayerSet.cpp
@@ -138,7 +138,6 @@ void GradeBeautyLayerSet::_validate(bool for_real) {
         updateLayerSetKnob(this, m_lsKnobData, layerCollection, inChannels, CategorizeFilterAllBeauty);
     }
     set_out_channels(activeChannelSet());
-    setLayerSetNodeLabel(this);
 }
 
 void GradeBeautyLayerSet::pixel_engine(const Row& in, int y, int x, int r, ChannelMask channels, Row& out) {

--- a/src/nuke/GradeLayerSet.cpp
+++ b/src/nuke/GradeLayerSet.cpp
@@ -100,7 +100,6 @@ void GradeLayerSet::_validate(bool for_real) {
         updateLayerSetKnob(this, m_lsKnobData, layerCollection, inChannels);
     }
     set_out_channels(activeChannelSet());
-    setLayerSetNodeLabel(this);
 }
 
 void GradeLayerSet::pixel_engine(const Row& in, int y, int x, int r,

--- a/src/nuke/MultiplyLayerSet.cpp
+++ b/src/nuke/MultiplyLayerSet.cpp
@@ -56,7 +56,6 @@ void MultiplyLayerSet::_validate(bool for_real) {
         updateLayerSetKnob(this, m_lsKnobData, layerCollection, inChannels);
     }
     set_out_channels(activeChannelSet());
-    setLayerSetNodeLabel(this);
 }
 
 void MultiplyLayerSet::in_channels(int input, ChannelSet& mask) const {

--- a/src/nuke/RemoveLayerSet.cpp
+++ b/src/nuke/RemoveLayerSet.cpp
@@ -57,7 +57,6 @@ void RemoveLayerSet::_validate(bool for_real) {
     if (validateLayerSetKnobUpdate(this, m_lsKnobData, layerCollection, inChannels)) {
         updateLayerSetKnob(this, m_lsKnobData, layerCollection, inChannels);
     }
-    setLayerSetNodeLabel(this);
 
     if (m_operation) { // keep
         info_.channels() &= m_lsKnobData.m_selectedChannels;


### PR DESCRIPTION
## Description

This PR adds basic autolabel and indicator callbacks to all nodes, they contain the node name and the LayerSet currently active on the node. 

_Might push all this back into c++ at a later date, because this is basically a workaround for not knowing (not documented) how to overload the c++ label mechanism yet_

Also solves connecting a new GradeBeauty Node to another node that has no cg layers (example: a checkerboard). GradeBeauty didn't really know what to do with this. now it does.


### code changes

- remove all label code from all c++ plugins 
- removes setLayerSetNodeLabel function
- delegate the node labeling to python autolabels
- simplify init.py, and refactor a bit
- handle missing layerSets on empty new nodes (fixes connecting a blank node to a node that doesn't contain the required layers)
- refactor and simplify LayerSet update code for readability, and less code duplication

## Type of change

bug fix, slight enhancement

## How Has This Been Tested?

tested this 12.0 on mac

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

