### PR TITLE
change documentation package extension to tar.gz

### DIFF
--- a/documentation/CMakeLists.txt
+++ b/documentation/CMakeLists.txt
@@ -13,8 +13,8 @@ add_custom_target(documentation ALL
 add_custom_target(documentation_package
     DEPENDS documentation
     COMMENT "creating documentation package for ${PROJECT_PACKAGE_NAME}"
-    COMMAND ${CMAKE_COMMAND} -E tar "cfvz" "${PROJECT_NAME}-${LAYER_ALCHEMY_VERSION_STRING}_documentation.tar.gz" "${CMAKE_CURRENT_BINARY_DIR}/documentation"
-    COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_NAME}-${LAYER_ALCHEMY_VERSION_STRING}_documentation.tar.gz" "../"
+    COMMAND ${CMAKE_COMMAND} -E tar "cfvz" "${PROJECT_NAME}-${LAYER_ALCHEMY_VERSION_STRING}-documentation.tar.gz" "${CMAKE_CURRENT_BINARY_DIR}/documentation"
+    COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_NAME}-${LAYER_ALCHEMY_VERSION_STRING}-documentation.tar.gz" "../"
 )
 
 install(


### PR DESCRIPTION
## Description

Forgot this commit, and wanted to see if the issue template worked. (it does!)

### code changes

- changed the documentation_package file name to reflect the naming used in recent releases

## Type of change

extremely minor

## How Has This Been Tested?

forgotten commit, release 0.9.0 was using this

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
