### PR TITLE
GradeBeauty : unwanted channels could slip into the engine segfault

### DIFF
--- a/include/version.h
+++ b/include/version.h
@@ -1,7 +1,7 @@
 #pragma once
 #define LAYER_ALCHEMY_VERSION_MAJOR 0
 #define LAYER_ALCHEMY_VERSION_MINOR 9
-#define LAYER_ALCHEMY_VERSION_PATCH 0
+#define LAYER_ALCHEMY_VERSION_PATCH 1
 
 #include <string>
 

--- a/src/nuke/GradeBeauty.cpp
+++ b/src/nuke/GradeBeauty.cpp
@@ -285,9 +285,9 @@ void GradeBeauty::_validate(bool for_real)
         setKnobDefaultValue(this);
         _validate(true); // this will refresh the node UI in case the node was blank
     }
-
-    calculateLayerValues(m_lsKnobData.m_selectedChannels, m_valueMap);
-    set_out_channels(activeChannelSet());
+    ChannelSet activeChannels = activeChannelSet();
+    calculateLayerValues(activeChannels - m_targetLayer, m_valueMap);
+    set_out_channels(activeChannels);
     info_.turn_on(m_targetLayer);
 }
 
@@ -383,14 +383,13 @@ void GradeBeauty::beautyPixelEngine(const Row& in, int y, int x, int r, ChannelS
 
 void GradeBeauty::pixel_engine(const Row& in, int y, int x, int r, ChannelMask channels, Row& out)
 {
-
     ChannelSet inChannels = ChannelSet(channels);
-    ChannelSet activeChannels = activeChannelSet();
     Row aRow(x, r);
     bool isTargetLayer = m_targetLayer.intersection(inChannels).size() == m_targetLayer.size();
     if (isTargetLayer)
     {
-        channelPixelEngine(in, y, x, r, m_lsKnobData.m_selectedChannels, aRow);
+        ChannelSet activeChannels = activeChannelSet();
+        channelPixelEngine(in, y, x, r, activeChannels - m_targetLayer, aRow);
         beautyPixelEngine(in, y, x, r, activeChannels, aRow);
     } 
     else


### PR DESCRIPTION
## Description

A friend of mine gave me a test frame from the redshift renderer to try out and I noticed that there was a segfault. That render had an extra channel in diffuse and GradeBeauty really didn't like that.

This PR doesn't include RedShift configurations of features, but fixes that segfault.

### code changes

- don't let unwanted channels creep into the pixel engine

## Type of change

patch

## How Has This Been Tested?

Nuke 11.3v3 linux, 12.0v4 osx

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
